### PR TITLE
 add stale base field

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ GitHub action that deals with stale issues in your project.
 
 - `ghToken` **Required**, GitHub token
 
+- `staleBaseField` *string*, field to calculate on how old is the issue, __default__: `updated_at`
 - `staleAfter` *int*, number of days to consider an issue to be stale, __default__: `30`
 - `closeAfter` *int*, number of days after the issue should be closed (0 days means off, must be higher than `staleAfter`), __default__: `0`
 

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
   ghToken:
     description: 'GitHub token'
     required: true
+  staleBaseField:
+    description: field to calculate on how old is the issue (available options: created_at, updated_at)
+    required: false
+    default: "update_at"
   staleAfter:
     description: number of days to consider an issue to be stale
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -4613,7 +4613,7 @@ class ActionIssueTriage {
 
         if (
           this.opts.closeAfter > this.opts.staleAfter &&
-          this._isOlderThan(issue.updated_at, this.opts.closeAfter)
+          this._isOlderThan(this._baseDate(issue), this.opts.closeAfter)
         ) {
           isClosingDown = true;
         }
@@ -4671,7 +4671,7 @@ class ActionIssueTriage {
 
   _filterOldIssues(issues) {
     return issues.filter(issue =>
-      this._isOlderThan(issue.updated_at, this.opts.staleAfter)
+      this._isOlderThan(this._baseDate(issue), this.opts.staleAfter)
     );
   }
 
@@ -4682,7 +4682,7 @@ class ActionIssueTriage {
      */
     let message = messageTemplate.replace(
       '%DAYS_OLD%',
-      this._getDaysSince(issue.updated_at)
+      this._getDaysSince(this._baseDate(issue))
     );
     message = message.replace('%AUTHOR%', issue.user.login);
 
@@ -4788,6 +4788,14 @@ class ActionIssueTriage {
       return false;
     }
     return true;
+  }
+
+  _baseDate(issue) {
+    if (this.opts.staleBaseField === "created_at") {
+      return issue.created_at
+    } else {
+      return issue.updated_at
+    }
   }
 }
 
@@ -7749,6 +7757,7 @@ const closeComment = core.getInput('staleComment') || closeCommentDefault;
 const staleLabel = core.getInput('staleLabel') || 'STALE';
 const showLogs = core.getInput('showLogs') || 'true';
 const issueLabels = core.getInput('issueLabels');
+const staleBaseField = core.getInput('staleBaseField') || "updated_at";
 
 const GH_TOKEN = core.getInput('ghToken', {
   required: true,
@@ -7763,7 +7772,8 @@ const options = {
   closeComment,
   staleLabel,
   showLogs: showLogs === 'true',
-  issueLabels
+  issueLabels,
+  staleBaseField
 };
 
 const action = new ActionIssueTriage(new github.GitHub(GH_TOKEN), options);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krizzu/issue_triage_action",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Github action that finds and handles old issues in project",
   "main": "dist/index.js",
   "author": "Krzysztof Borowy <dev@krizzu.dev>",

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ const closeComment = core.getInput('staleComment') || closeCommentDefault;
 const staleLabel = core.getInput('staleLabel') || 'STALE';
 const showLogs = core.getInput('showLogs') || 'true';
 const issueLabels = core.getInput('issueLabels');
+const staleBaseField = core.getInput('staleBaseField') || "updated_at";
 
 const GH_TOKEN = core.getInput('ghToken', {
   required: true,
@@ -29,7 +30,8 @@ const options = {
   closeComment,
   staleLabel,
   showLogs: showLogs === 'true',
-  issueLabels
+  issueLabels,
+  staleBaseField
 };
 
 const action = new ActionIssueTriage(new github.GitHub(GH_TOKEN), options);

--- a/src/issueTriage.js
+++ b/src/issueTriage.js
@@ -219,9 +219,9 @@ class ActionIssueTriage {
 
   _baseDate(issue) {
     if (this.opts.staleBaseField === "created_at") {
-      issue.created_at
+      return issue.created_at
     } else {
-      issue.updated_at
+      return issue.updated_at
     }
   }
 }

--- a/src/issueTriage.js
+++ b/src/issueTriage.js
@@ -40,7 +40,7 @@ class ActionIssueTriage {
 
         if (
           this.opts.closeAfter > this.opts.staleAfter &&
-          this._isOlderThan(issue.updated_at, this.opts.closeAfter)
+          this._isOlderThan(this._baseDate(issue), this.opts.closeAfter)
         ) {
           isClosingDown = true;
         }
@@ -98,7 +98,7 @@ class ActionIssueTriage {
 
   _filterOldIssues(issues) {
     return issues.filter(issue =>
-      this._isOlderThan(issue.updated_at, this.opts.staleAfter)
+      this._isOlderThan(this._baseDate(issue), this.opts.staleAfter)
     );
   }
 
@@ -109,7 +109,7 @@ class ActionIssueTriage {
      */
     let message = messageTemplate.replace(
       '%DAYS_OLD%',
-      this._getDaysSince(issue.updated_at)
+      this._getDaysSince(this._baseDate(issue))
     );
     message = message.replace('%AUTHOR%', issue.user.login);
 
@@ -215,6 +215,14 @@ class ActionIssueTriage {
       return false;
     }
     return true;
+  }
+
+  _baseDate(issue) {
+    if (this.opts.staleBaseField === "created_at") {
+      issue.created_at
+    } else {
+      issue.updated_at
+    }
   }
 }
 


### PR DESCRIPTION
Add `staleBaseField` configuration option  used to determine how old is the issue, days can be counted from
when the issue was created (`created_at`) or last updated (`updated_at`)


See LeadSimple/LeadSimple#9626